### PR TITLE
docs: use tr

### DIFF
--- a/buildkite-agent-builder-private-git/tpl/settings.toml
+++ b/buildkite-agent-builder-private-git/tpl/settings.toml
@@ -4,4 +4,7 @@
 token = "YOUR BUILDKITE TOKEN"
 
 [ssh]
-id_rsa = "copy YOUR_SSH_PRIVATE_KEY encoded with base64- e.g.: echo -n "$(cat id_rsa)" | base64"
+id_rsa = """
+  copy YOUR_SSH_PRIVATE_KEY encoded with base64 e.g.:
+  $ tr --delete '\n' < ~/.ssh/id_rsa | base64 | tr --delete '\n'
+"""

--- a/buildkite-agent-private-git/tpl/settings.toml
+++ b/buildkite-agent-private-git/tpl/settings.toml
@@ -4,4 +4,7 @@
 token = "YOUR BUILDKITE TOKEN"
 
 [ssh]
-id_rsa = "copy YOUR_SSH_PRIVATE_KEY encoded with base64- e.g.: echo -n "$(cat id_rsa)" | base64"
+id_rsa = """
+  copy YOUR_SSH_PRIVATE_KEY encoded with base64 e.g.:
+  $ tr --delete '\n' < ~/.ssh/id_rsa | base64 | tr --delete '\n'
+"""


### PR DESCRIPTION
Heya, super tiny patch here. This addresses the lil snip of documentation about copying the `id_rsa` files in `base64` inside the `.toml` files:
- To me `echo -n` feels a bit like a hack because it's a non standard flag; internally it triggers a bit of a warning. This patch changes it to use `tr --delete` which feels a bit more, um, elegant. Maybe it's just me tho
- Piping through `base64`, at least on my machine, returns a newline delimited string. So by piping it through `tr --delete` again we get a nice one liner (which is what I gathered the `.toml` files wants).

Hope this was somewhat useful. Thanks! :sparkles:
