### PR TITLE
docs: fix newline strippings

### DIFF
--- a/buildkite-agent-builder-private-git/tpl/settings.toml
+++ b/buildkite-agent-builder-private-git/tpl/settings.toml
@@ -6,5 +6,5 @@ token = "YOUR BUILDKITE TOKEN"
 [ssh]
 id_rsa = """
   copy YOUR_SSH_PRIVATE_KEY encoded with base64 e.g.:
-  $ tr --delete '\n' < ~/.ssh/id_rsa | base64 | tr --delete '\n'
+  $ base64 < ~/.ssh/id_rsa | tr --delete '\n'
 """

--- a/buildkite-agent-private-git/tpl/settings.toml
+++ b/buildkite-agent-private-git/tpl/settings.toml
@@ -6,5 +6,5 @@ token = "YOUR BUILDKITE TOKEN"
 [ssh]
 id_rsa = """
   copy YOUR_SSH_PRIVATE_KEY encoded with base64 e.g.:
-  $ tr --delete '\n' < ~/.ssh/id_rsa | base64 | tr --delete '\n'
+  $ base64 < ~/.ssh/id_rsa | tr --delete '\n'
 """


### PR DESCRIPTION
As discussed on slack; this only strips the newlines _after_ the base64
has been applied so that the keys don't end up mangled (and the "enter passphrase" prompt is omitted). Thanks!
