### PR TITLE
Fix template for buildkite-agent image

### DIFF
--- a/buildkite-agent/templates/deployment.yaml
+++ b/buildkite-agent/templates/deployment.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccount: {{ .Release.Name }}
       containers:
         - name: buildkite
-          image: "{{ .Values.image.repository }}-{{ .Values.image.tag  }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag  }}"
           imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
           securityContext:
             privileged: true


### PR DESCRIPTION
After our discussion on #8 I went ahead and packaged/indexed the repo myself locally and was able to get the agent running successfully. Just tried a minimal test with an agent token.

I did have to make this one tiny change since initially the deployment couldn't pull the image and failed.