### PR TITLE
Add note to documentation about multiple tags

### DIFF
--- a/charts/buildkite/README.md
+++ b/charts/buildkite/README.md
@@ -28,7 +28,7 @@ $ helm install buildkite --name bk-agent --namespace buildkite \
 Where `--set` values contain:
 ```
 agentToken: Buildkite token read from file
-agentMeta: tagging agent with - role=production
+agentMeta: tagging agent with - role=production (to add multiple tags, you must separate them with an escaped comma, like this: role=production\,queue=kubernetes)
 privateSshKey: private SSH key read from file
 ```
 


### PR DESCRIPTION
After trying commas, semicolons, spaces, newlines, and then finally backslash-escaped commas, I managed to discover how to add multiple tags to an agent spawned with this chart. Since I didn't see any place in the documentation where this was explained, I figured I'd add a note.