### PR TITLE
Use nindent for conditional yaml insertions

### DIFF
--- a/charts/buildkite/templates/deployment.yaml
+++ b/charts/buildkite/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
                   key: agent-ssh
             {{- end }}
             # EXTRA BUILDKITE AGENT ENV VARS
-{{- if .Values.extraEnv }}{{ toYaml .Values.extraEnv | indent 12 }}{{- end }}
+{{- if .Values.extraEnv }}{{ toYaml .Values.extraEnv | nindent 12 }}{{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           volumeMounts:


### PR DESCRIPTION
When inserting indented yaml, for the `extraEnv` option, it's currently being appended without a newline because of the `-` used to collapse whitespace on the `if` statement. This leads to an invalid deployment.

For example, `helm template buildkite --set agent.token=abc --set extraEnv="{name: test, value: test2}"`, results in:

```
         env:
            # BUILDKITE AGENT ENV VARS
            - name: BUILDKITE_AGENT_TOKEN
              valueFrom:
                secretKeyRef:
                  name: RELEASE-NAME-buildkite
                  key: agent-token
            - name: BUILDKITE_AGENT_META_DATA
              value: "role=agent"
            # EXTRA BUILDKITE AGENT ENV VARS            - 'name: ''test'''
            - ' value: ''test2'''
```

This PR switches from using the `indent` helper to `nindent`, which prepends a newline to the indented yaml.