### PR TITLE
Refactor RBAC to allow specifying rules

### DIFF
--- a/stable/agent/Chart.yaml
+++ b/stable/agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Buildkite Agent Chart
 name: agent
-version: 0.3.9
+version: 0.3.10
 appVersion: 3.12.0
 icon: https://raw.githubusercontent.com/buildkite/site/master/assets/images/brand-assets/buildkite-mark-on-light.png
 keywords:

--- a/stable/agent/README.md
+++ b/stable/agent/README.md
@@ -73,6 +73,8 @@ Parameter | Description | Default
 `privateSshKey` | Agent ssh key for git access | `nil`
 `registryCreds.gcrServiceAccountKey` | GCP Service account json key | `nil`
 `registryCreds.dockerConfig` | Private registry docker config.json | `nil`
+`rbac.create` | Whether to create RBAC resources to be used by the pod | `false`
+`rbac.role.rules` | List of rules following the role specification | See [values.yaml](values.yaml)
 `volumeMounts` | Extra volumeMounts configuration | `nil`
 `volumes` | Extra volumes configuration | `nil`
 `resources` | Liveness probe for docker socket | `{}`

--- a/stable/agent/templates/clusterrole.yaml
+++ b/stable/agent/templates/clusterrole.yaml
@@ -1,51 +1,8 @@
-{{- if .Values.rbac.enabled }}
+{{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ template "fullname" . }}
 rules:
-  - apiGroups:
-      - ""
-    resources:
-      - namespaces
-    verbs:
-      - watch
-      - list
-  - apiGroups:
-      - ""
-    resources:
-      - secrets
-    verbs:
-      - get
-      - watch
-      - list
-  - apiGroups:
-      - ""
-      - extensions
-      - apps
-      - batch
-    resources:
-      - pods
-      - replicasets
-      - replicationcontrollers
-      - statefulsets
-      - deployments
-      - daemonsets
-      - jobs
-      - cronjobs
-    verbs:
-      - get
-      - delete # required to delete pods during force upgrade of the same tag
-      - watch
-      - list
-      - update
-  - apiGroups:
-      - ""
-    resources:
-      - configmaps
-      - secrets
-    verbs:
-      - get
-      - create
-      - update
+{{ toYaml .Values.rbac.role.rules | indent 2 }}
 {{- end }}

--- a/stable/agent/templates/clusterrolebinding.yaml
+++ b/stable/agent/templates/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.enabled }}
+{{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/stable/agent/values.yaml
+++ b/stable/agent/values.yaml
@@ -91,7 +91,54 @@ affinity: {}
 
 # RBAC manifests management
 rbac:
-  enabled: false
+  create: false
+  role:
+    ## Rules to create. It follows the role specification
+    rules:
+      - apiGroups:
+          - ""
+        resources:
+          - namespaces
+        verbs:
+          - watch
+          - list
+      - apiGroups:
+          - ""
+        resources:
+          - secrets
+        verbs:
+          - get
+          - watch
+          - list
+      - apiGroups:
+          - ""
+          - extensions
+          - apps
+          - batch
+        resources:
+          - pods
+          - replicasets
+          - replicationcontrollers
+          - statefulsets
+          - deployments
+          - daemonsets
+          - jobs
+          - cronjobs
+        verbs:
+          - get
+          - delete # required to delete pods during force upgrade of the same tag
+          - watch
+          - list
+          - update
+      - apiGroups:
+          - ""
+        resources:
+          - configmaps
+          - secrets
+        verbs:
+          - get
+          - create
+          - update
 
 podDisruptionBudget:
   enabled: false


### PR DESCRIPTION
**What this PR does / why we need it**: Allow more customisable RBAC

**Which issue this PR fixes**: fixes #47 

**Special notes for your reviewer**: I copied your example from #47 directly - changing `rbac.enabled` to `rbac.create` which now breaks backwards compatibility. Let me know if that's intentional or not and I can change it back. It also wasn't documented in the README so I added it

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
