### PR TITLE
dind tweaks

### DIFF
--- a/stable/agent/templates/deployment.yaml
+++ b/stable/agent/templates/deployment.yaml
@@ -65,6 +65,10 @@ spec:
             {{- if .Values.dind.enabled }}
             - name: DOCKER_HOST
               value: "tcp://localhost:{{ .Values.dind.port | default "2375" }}"
+            - name: BUILDKITE_BUILD_PATH
+              value: "/var/buildkite/builds"
+            - name: BUILDKITE_PLUGINS_PATH
+              value: "/var/buildkite/plugins"
             {{- end }}
             # EXTRA BUILDKITE AGENT ENV VARS
 {{- if .Values.extraEnv }}


### PR DESCRIPTION
**What this PR does / why we need it**:
When `dind` is enabled, set builds and plugins path to use the shared volume. This allowed the docker-compose plugin to be used inside of GKE.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [x] Variables are documented in the README.md
