### PR TITLE
Allow ServiceAccount annotations to be configured

### DIFF
--- a/stable/agent/README.md
+++ b/stable/agent/README.md
@@ -73,6 +73,7 @@ Parameter | Description | Default
 `privateSshKey` | Agent ssh key for git access | `nil`
 `registryCreds.gcrServiceAccountKey` | GCP Service account json key | `nil`
 `registryCreds.dockerConfig` | Private registry docker config.json | `nil`
+`serviceAccount.annotation` | Extra annotations for the generated ServiceAccount | `{}`
 `rbac.create` | Whether to create RBAC resources to be used by the pod | `false`
 `rbac.role.rules` | List of rules following the role specification | See [values.yaml](values.yaml)
 `volumeMounts` | Extra volumeMounts configuration | `nil`

--- a/stable/agent/templates/service-account.yaml
+++ b/stable/agent/templates/service-account.yaml
@@ -7,3 +7,7 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- if .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml .Values.serviceAccount.annotations | indent 4 }}
+{{- end }}

--- a/stable/agent/values.yaml
+++ b/stable/agent/values.yaml
@@ -62,6 +62,9 @@ registryCreds:
   # to be used with imagePullSecrets
   dockerconfigjson: ""
 
+serviceAccount:
+  annotations: {}
+
  # Uncomment below to enable docker socket liveness probe
 livenessProbe:
   # initialDelaySeconds: 15


### PR DESCRIPTION
**What this PR does / why we need it**:
This is useful for linking to a GCP service account or ECS IAM.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [x] Variables are documented in the README.md
