### PR TITLE
Use agent tags instead of meta-data

### DIFF
--- a/stable/agent/README.md
+++ b/stable/agent/README.md
@@ -66,7 +66,7 @@ Parameter | Description | Default
 `image.tag` | Image tag | ``
 `image.pullPolicy` | Image pull policy | `IfNotPresent`
 `agent.token` | Agent token | Must be specified
-`agent.meta` | Agent meta-data | `role=agent`
+`agent.tags` | Agent tags | `role=agent`
 `enableHostDocker` | Mount docker socket | `true`
 `securityContext` | Pod security context to set | `{}`
 `extraEnv` | Agent extra env vars | `nil`

--- a/stable/agent/templates/deployment.yaml
+++ b/stable/agent/templates/deployment.yaml
@@ -53,8 +53,8 @@ spec:
                 secretKeyRef:
                   name: {{ template "fullname" . }}
                   key: agent-token
-            - name: BUILDKITE_AGENT_META_DATA
-              value: "{{ .Values.agent.meta }}"
+            - name: BUILDKITE_AGENT_TAGS
+              value: "{{ .Values.agent.tags }}"
             {{- if .Values.privateSshKey }}
             - name: SSH_PRIVATE_RSA_KEY
               valueFrom:

--- a/stable/agent/values.yaml
+++ b/stable/agent/values.yaml
@@ -14,8 +14,8 @@ image:
 agent:
   # Your Buildkite agent token, it must be set
   token: ""
-  # Agent meta-data, which can be used to assign jobs
-  meta: "role=agent"
+  # Agent tags, which can be used to assign jobs
+  tags: "role=agent"
 
 # Enable mounting the hosts docker socket into the agent container
 enableHostDocker: true


### PR DESCRIPTION
**What this PR does / why we need it**:
`BUILDKITE_AGENT_META_DATA` was replaced by `BUILDKITE_AGENT_TAGS`.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [x] Variables are documented in the README.md
