### PR TITLE
Configure /docker-entrypoint.d via a ConfigMap

### DIFF
--- a/stable/agent/README.md
+++ b/stable/agent/README.md
@@ -73,6 +73,7 @@ Parameter | Description | Default
 `privateSshKey` | Agent ssh key for git access | `nil`
 `registryCreds.gcrServiceAccountKey` | GCP Service account json key | `nil`
 `registryCreds.dockerConfig` | Private registry docker config.json | `nil`
+`entrypointd` | Add files to /docker-entrypoint.d/ via a ConfigMap | `{}`
 `rbac.create` | Whether to create RBAC resources to be used by the pod | `false`
 `rbac.role.rules` | List of rules following the role specification | See [values.yaml](values.yaml)
 `volumeMounts` | Extra volumeMounts configuration | `nil`

--- a/stable/agent/templates/configmap-entrypointd.yaml
+++ b/stable/agent/templates/configmap-entrypointd.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "fullname" . }}-entrypointd
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+{{ toYaml .Values.entrypointd | indent 2 }}

--- a/stable/agent/templates/deployment.yaml
+++ b/stable/agent/templates/deployment.yaml
@@ -92,6 +92,10 @@ spec:
             - name: shared-volume
               mountPath: "/var/buildkite"
             {{- end }}
+            {{- if .Values.entrypointd }}
+            - name: entrypointd
+              mountPath: /docker-entrypoint.d/
+            {{- end }}
 {{- if .Values.dind.enabled }}
         - name: dind
           image: {{ .Values.dind.image | default "docker:19.03-dind" }}
@@ -129,6 +133,12 @@ spec:
           emptyDir: {}
         - name: shared-volume
           emptyDir: {}
+        {{- end }}
+        {{- if .Values.entrypointd }}
+        - name: entrypointd
+          configMap:
+            name: {{ template "fullname" . }}-entrypointd
+            defaultMode: 0777
         {{- end }}
     {{- if .Values.nodeSelector }}
       nodeSelector:

--- a/stable/agent/values.yaml
+++ b/stable/agent/values.yaml
@@ -62,6 +62,13 @@ registryCreds:
   # to be used with imagePullSecrets
   dockerconfigjson: ""
 
+# Add scriptes to /docker-entrypoint.d/ via a ConfigMap
+entrypointd: {}
+# 01-install-kubectl: |
+#   #!/bin/bash
+#   set -euo pipefail
+#   apt-get update && apt-get install -y kubectl
+
  # Uncomment below to enable docker socket liveness probe
 livenessProbe:
   # initialDelaySeconds: 15


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow `/docker-entrypoint.d` to be populated via a ConfigMap. This is useful to install dependencies required by builds (ie. `gcloud`, `kubectl`, etc).

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [x] Variables are documented in the README.md
