### PR TITLE
Multiple chart improvements

### DIFF
--- a/stable/agent/Chart.yaml
+++ b/stable/agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Buildkite Agent Chart
 name: agent
-version: 0.3.15
+version: 0.3.16
 appVersion: 3.17.0
 icon: https://raw.githubusercontent.com/buildkite/site/master/assets/images/brand-assets/buildkite-mark-on-light.png
 keywords:

--- a/stable/agent/README.md
+++ b/stable/agent/README.md
@@ -26,11 +26,11 @@ helm install --name bk-agent --namespace buildkite buildkite/agent \
     --set agent.token="BUILDKITE_AGENT_TOKEN"
 ```
 
-To install the chart with the release name `bk-agent` and set Agent meta-data and git repo SSH key:
+To install the chart with the release name `bk-agent` and set Agent tags and git repo SSH key:
 
 ```console
 helm install --name bk-agent --namespace buildkite buildkite/agent \
-  --set agent.token="$(cat buildkite.token)",agent.meta="role=production" \
+  --set agent.token="$(cat buildkite.token)",agent.tags="role=production" \
   --set privateSshKey="$(cat buildkite.key)"  \
   --set registryCreds.gcrServiceAccountKey="$(cat gcr_service_account.key | base64)"
 ```
@@ -66,7 +66,7 @@ Parameter | Description | Default
 `image.tag` | Image tag | ``
 `image.pullPolicy` | Image pull policy | `IfNotPresent`
 `agent.token` | Agent token | Must be specified
-`agent.meta` | Agent meta-data | `role=agent`
+`agent.tags` | Agent tags | `role=agent`
 `enableHostDocker` | Mount docker socket | `true`
 `securityContext` | Pod security context to set | `{}`
 `extraEnv` | Agent extra env vars | `nil`

--- a/stable/agent/README.md
+++ b/stable/agent/README.md
@@ -73,6 +73,7 @@ Parameter | Description | Default
 `privateSshKey` | Agent ssh key for git access | `nil`
 `registryCreds.gcrServiceAccountKey` | GCP Service account json key | `nil`
 `registryCreds.dockerConfig` | Private registry docker config.json | `nil`
+`entrypointd` | Add files to /docker-entrypoint.d/ via a ConfigMap | `{}`
 `rbac.create` | Whether to create RBAC resources to be used by the pod | `false`
 `rbac.role.rules` | List of rules following the role specification | See [values.yaml](values.yaml)
 `volumeMounts` | Extra volumeMounts configuration | `nil`

--- a/stable/agent/README.md
+++ b/stable/agent/README.md
@@ -74,6 +74,7 @@ Parameter | Description | Default
 `registryCreds.gcrServiceAccountKey` | GCP Service account json key | `nil`
 `registryCreds.dockerConfig` | Private registry docker config.json | `nil`
 `entrypointd` | Add files to /docker-entrypoint.d/ via a ConfigMap | `{}`
+`serviceAccount.annotation` | Extra annotations for the generated ServiceAccount | `{}`
 `rbac.create` | Whether to create RBAC resources to be used by the pod | `false`
 `rbac.role.rules` | List of rules following the role specification | See [values.yaml](values.yaml)
 `volumeMounts` | Extra volumeMounts configuration | `nil`

--- a/stable/agent/templates/configmap-entrypointd.yaml
+++ b/stable/agent/templates/configmap-entrypointd.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.entrypointd }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "fullname" . }}-entrypointd
+  labels:
+    app: {{ template "name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+{{ toYaml .Values.entrypointd | indent 2 }}
+{{- end }}

--- a/stable/agent/templates/deployment.yaml
+++ b/stable/agent/templates/deployment.yaml
@@ -65,6 +65,12 @@ spec:
             {{- if .Values.dind.enabled }}
             - name: DOCKER_HOST
               value: "tcp://localhost:{{ .Values.dind.port | default "2375" }}"
+            - name: BUILDKITE_BUILD_PATH
+              value: "/var/buildkite/builds"
+            - name: BUILDKITE_PLUGINS_PATH
+              value: "/var/buildkite/plugins"
+            - name: BUILDKITE_HOOKS_PATH
+              value: "/var/buildkite/hooks"
             {{- end }}
             # EXTRA BUILDKITE AGENT ENV VARS
 {{- if .Values.extraEnv }}

--- a/stable/agent/templates/deployment.yaml
+++ b/stable/agent/templates/deployment.yaml
@@ -98,6 +98,10 @@ spec:
             - name: shared-volume
               mountPath: "/var/buildkite"
             {{- end }}
+            {{- if .Values.entrypointd }}
+            - name: entrypointd
+              mountPath: /docker-entrypoint.d/
+            {{- end }}
 {{- if .Values.dind.enabled }}
         - name: dind
           image: {{ .Values.dind.image | default "docker:19.03-dind" }}
@@ -135,6 +139,12 @@ spec:
           emptyDir: {}
         - name: shared-volume
           emptyDir: {}
+        {{- end }}
+        {{- if .Values.entrypointd }}
+        - name: entrypointd
+          configMap:
+            name: {{ template "fullname" . }}-entrypointd
+            defaultMode: 0777
         {{- end }}
     {{- if .Values.nodeSelector }}
       nodeSelector:

--- a/stable/agent/templates/deployment.yaml
+++ b/stable/agent/templates/deployment.yaml
@@ -53,8 +53,8 @@ spec:
                 secretKeyRef:
                   name: {{ template "fullname" . }}
                   key: agent-token
-            - name: BUILDKITE_AGENT_META_DATA
-              value: "{{ .Values.agent.meta }}"
+            - name: BUILDKITE_AGENT_TAGS
+              value: "{{ .Values.agent.tags }}"
             {{- if .Values.privateSshKey }}
             - name: SSH_PRIVATE_RSA_KEY
               valueFrom:

--- a/stable/agent/templates/service-account.yaml
+++ b/stable/agent/templates/service-account.yaml
@@ -7,3 +7,7 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- if .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml .Values.serviceAccount.annotations | indent 4 }}
+{{- end }}

--- a/stable/agent/values.yaml
+++ b/stable/agent/values.yaml
@@ -14,8 +14,8 @@ image:
 agent:
   # Your Buildkite agent token, it must be set
   token: ""
-  # Agent meta-data, which can be used to assign jobs
-  meta: "role=agent"
+  # Agent tags, which can be used to assign jobs
+  tags: "role=agent"
 
 # Enable mounting the hosts docker socket into the agent container
 enableHostDocker: true

--- a/stable/agent/values.yaml
+++ b/stable/agent/values.yaml
@@ -62,6 +62,13 @@ registryCreds:
   # to be used with imagePullSecrets
   dockerconfigjson: ""
 
+# Add scriptes to /docker-entrypoint.d/ via a ConfigMap
+entrypointd: {}
+# 01-install-kubectl: |
+#   #!/bin/bash
+#   set -euo pipefail
+#   apt-get update && apt-get install -y kubectl
+
  # Uncomment below to enable docker socket liveness probe
 livenessProbe:
   # initialDelaySeconds: 15

--- a/stable/agent/values.yaml
+++ b/stable/agent/values.yaml
@@ -69,6 +69,9 @@ entrypointd: {}
 #   set -euo pipefail
 #   apt-get update && apt-get install -y kubectl
 
+serviceAccount:
+  annotations: {}
+
  # Uncomment below to enable docker socket liveness probe
 livenessProbe:
   # initialDelaySeconds: 15


### PR DESCRIPTION
**What this PR does / why we need it**:
- Use shared-volume in buildkite when using dind
- Use agent tags instead of meta-data
- Configure /docker-entrypoint.d via a ConfigMap
- Allow ServiceAccount annotations to be configured

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
