### PR TITLE
Add securityContext for the Buildkite agent pod.

### DIFF
--- a/stable/agent/Chart.yaml
+++ b/stable/agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Buildkite Agent Chart
 name: agent
-version: 0.3.16
+version: 0.3.17
 appVersion: 3.17.0
 icon: https://raw.githubusercontent.com/buildkite/site/master/assets/images/brand-assets/buildkite-mark-on-light.png
 keywords:

--- a/stable/agent/README.md
+++ b/stable/agent/README.md
@@ -68,7 +68,8 @@ Parameter | Description | Default
 `agent.token` | Agent token | Must be specified
 `agent.tags` | Agent tags | `role=agent`
 `enableHostDocker` | Mount docker socket | `true`
-`securityContext` | Pod security context to set | `{}`
+`podSecurityContext` | Pod security context to set | `{}`
+`securityContext` | Container security context to set | `{}`
 `extraEnv` | Agent extra env vars | `nil`
 `privateSshKey` | Agent ssh key for git access | `nil`
 `registryCreds.gcrServiceAccountKey` | GCP Service account json key | `nil`

--- a/stable/agent/templates/deployment.yaml
+++ b/stable/agent/templates/deployment.yaml
@@ -117,6 +117,10 @@ spec:
             mountPath: "/var/buildkite"
 {{- end }}
 {{- if .Values.podContainers }}{{ toYaml .Values.podContainers | nindent 8 }}{{- end }}
+{{- with .Values.podSecurityContext }}
+      securityContext:
+{{ toYaml . | indent 8 }}
+{{- end }}
       volumes:
 {{- if .Values.volumes }}{{ toYaml .Values.volumes | nindent 8 }}{{- end }}
 {{- if .Values.enableHostDocker }}

--- a/stable/agent/values.yaml
+++ b/stable/agent/values.yaml
@@ -20,9 +20,13 @@ agent:
 # Enable mounting the hosts docker socket into the agent container
 enableHostDocker: true
 
-# Enable security context configuration
+# Enable security context configuration for the container
 securityContext: {}
   # privileged: true
+
+# Enable security context configuration for the pod
+podSecurityContext: {}
+  # fsGroup: 1000
 
 # Extra env vars to be passed
 # If you do want to pass extra env vars to the agent, uncomment the following


### PR DESCRIPTION
Signed-off-by: Jim Barber <jim.barber@healthengine.com.au>

<!--
Thank you for contributing to buildkite/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

My use-case is to get AWS's IAM Roles for Service Accounts working.
But this change also allows any of the pod `securityContext` values to be set:
https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podsecuritycontext-v1-core

In order for AWS's IAM Roles for Service Accounts to work, I need to be
able to set `securityContext.fsGroup` for the Buildkite agent pod.
You cannot set `fsGroup` in the `securityContext` that is at the container level.
   
With this change I can provide the `podSecurityContext.fsGroup: 1000`
value at deployment time.
This then makes the token mounted with a group ownership of `1000`
and permission `640` (`-rw-r----`) so that the agent can read it and 
correctly assume the IAM role it requires.
    
By default, the pod `securityContext` is empty so that existing
deployments are unaffected. This leaves tokens mounted with group
ownership of `root` and permission `600` (`-rw-------`).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
