### PR TITLE
Change place of imagePullSecrets in deployment spec.

### DIFF
--- a/stable/agent/Chart.yaml
+++ b/stable/agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Buildkite Agent Chart
 name: agent
-version: 0.4.3
+version: 0.4.4
 appVersion: 3.22.1
 icon: https://buildkite.com/_next/static/assets/assets/images/brand-assets/buildkite-logo-portrait-on-light-61fc0230.png
 keywords:

--- a/stable/agent/templates/deployment.yaml
+++ b/stable/agent/templates/deployment.yaml
@@ -34,14 +34,14 @@ spec:
 {{- end }}
     spec:
       serviceAccount: {{ template "fullname" . }}
+      {{- if .Values.registryCreds.dockerconfigjson }}
+      imagePullSecrets:
+      - name: {{ template "fullname" . }}-dockerconfigjson
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if .Values.registryCreds.dockerconfigjson }}
-          imagePullSecrets:
-          - name: {{ template "fullname" . }}-dockerconfigjson
-          {{- end }}
 {{- with .Values.securityContext }}
           securityContext:
 {{ toYaml . | indent 12 }}


### PR DESCRIPTION
**What this PR does / why we need it**: Change place of `imagePullSecrets` in deployment spec because `containers` not support `imagePullSecrets` see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#container-v1-core
