### PR TITLE
Add a note about dind.enabled option in the README

### DIFF
--- a/stable/agent/Chart.yaml
+++ b/stable/agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Buildkite Agent Chart
 name: agent
-version: 0.4.7
+version: 0.4.8
 appVersion: 3.25.0
 icon: https://buildkite.com/_next/static/assets/assets/images/brand-assets/buildkite-logo-portrait-on-light-61fc0230.png
 keywords:

--- a/stable/agent/README.md
+++ b/stable/agent/README.md
@@ -35,6 +35,8 @@ helm install --name bk-agent --namespace buildkite buildkite/agent \
   --set registryCreds.gcrServiceAccountKey="$(cat gcr_service_account.key | base64)"
 ```
 
+> **Note**: if your pipeline uses docker for build images or run containers, you must set `dind.enabled` to `true`.
+
 Where `--set` values contain:
 ```
 agentToken: Buildkite token read from file


### PR DESCRIPTION
This commit adds a note about the requirements for use docker inside K8S containers. It aims at people without much experience in K8S and its terminology (like me) and tries to point them in the right direction.
