### PR TITLE
Ability to control resources for dind container

### DIFF
--- a/stable/agent/Chart.yaml
+++ b/stable/agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Buildkite Agent Chart
 name: agent
-version: 0.4.8
+version: 0.5.0
 appVersion: 3.25.0
 icon: https://buildkite.com/_next/static/assets/assets/images/brand-assets/buildkite-logo-portrait-on-light-61fc0230.png
 keywords:

--- a/stable/agent/README.md
+++ b/stable/agent/README.md
@@ -92,6 +92,7 @@ Parameter | Description | Default
 `dind.enabled` | Enable preconfigured Docker-in-Docker (DinD) pod configuration | `false`
 `dind.image` | Image to use for Docker-in-Docker (DinD) pod container | `docker:19.03-dind`
 `dind.port` | Port Docker-in-Docker (DinD) daemon listens on as REST request proxy | `2375`
+`dind.resources` | Pod resource requests & limits for dind sidecar (if enabled) | `{}`
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/stable/agent/templates/deployment.yaml
+++ b/stable/agent/templates/deployment.yaml
@@ -119,6 +119,8 @@ spec:
           - name: service-key
             mountPath: /etc/service_key
           {{- end }}
+          resources:
+{{ toYaml .Values.dind.resources | indent 12 }}
 {{- end }}
 {{- if .Values.podContainers }}{{ toYaml .Values.podContainers | nindent 8 }}{{- end }}
 {{- with .Values.podSecurityContext }}

--- a/stable/agent/values.yaml
+++ b/stable/agent/values.yaml
@@ -176,3 +176,14 @@ dind:
   enabled: false
   image: docker:19.03-dind
   port: 2375
+  resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 500m
+  #  memory: 1024Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi


### PR DESCRIPTION
This changeset adds the ability to control the kubernetes resources
requests/limits for the sidecar "dind" container, if you are running
this chart with "dind" enabled. This is available in the values via

```yaml
dind:
  resources:
    limits:
      cpu: 500m
      memory: 1024Mi
```

which mimics the resources block for the agent itself.
