### PR TITLE
Improve docs for adding agent hooks

### DIFF
--- a/stable/agent/Chart.yaml
+++ b/stable/agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Buildkite Agent Chart
 name: agent
-version: 0.5.0
+version: 0.5.1
 appVersion: 3.25.0
 icon: https://buildkite.com/_next/static/assets/assets/images/brand-assets/buildkite-logo-portrait-on-light-61fc0230.png
 keywords:

--- a/stable/agent/README.md
+++ b/stable/agent/README.md
@@ -107,3 +107,23 @@ helm install --name bk-agent --namespace buildkite buildkite/agent -f values.yam
 ## Buildkite pipeline examples
 
 Check for examples of `pipeline.yml` and `build/deploy` scripts [here](pipeline-examples).
+
+
+## Adding agent hooks to agent pods
+
+Adding your own hooks (e.g. environment hooks) depends on whether you use DinD or not.
+
+#### Without Docker-in-Docker
+Without using DinD, you can follow the lower part of the guide [here](https://buildkite.com/docs/agent/v3/docker#adding-hooks) 
+
+#### With Docker-in-Docker
+As the hooks directory is set to a shared dir, currently the best way to add your own hooks while using DinD consists of two steps.
+1. Follow the guide above for usage without DinD.
+2. Add an entrypoint script to your values.yml that copies the hooks from the image to the shared dir. E.g:
+```
+entrypointd: 
+  01-copy-hooks: |
+    #!/bin/sh
+    set -euo pipefail
+    cp /buildkite/hooks/* /var/buildkite/hooks
+```

--- a/stable/agent/README.md
+++ b/stable/agent/README.md
@@ -120,6 +120,7 @@ Without using DinD, you can follow the lower part of the guide [here](https://bu
 As the hooks directory is set to a shared dir, currently the best way to add your own hooks while using DinD consists of two steps.
 1. Follow the guide above for usage without DinD.
 2. Add an entrypoint script to your values.yml that copies the hooks from the image to the shared dir. E.g:
+
 ```
 entrypointd: 
   01-copy-hooks: |

--- a/stable/agent/README.md
+++ b/stable/agent/README.md
@@ -125,5 +125,6 @@ entrypointd:
   01-copy-hooks: |
     #!/bin/sh
     set -euo pipefail
-    cp /buildkite/hooks/* /var/buildkite/hooks
+    mkdir -p /var/buildkite/hooks
+    cp /buildkite/hooks/* /var/buildkite/hooks/.
 ```


### PR DESCRIPTION
<!--
Thank you for contributing to buildkite/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:
We use a pipeline that utilizes the docker plugin, thus we need to enable the DinD feature.
The DinD feature sets the `BUILDKITE_HOOKS_PATH` to `/var/buildkite/hooks` which sits in a emptyDir shared-dir mounted at `/var/buildkite`.

I am not exactly shure why the hooks dir is set as well, but I have not enough experience to decide if removing this would break current deployments.

The problem that comes with setting `BUILDKITE_HOOKS_PATH` to a dir in the emptyDir shared-dir comes into play when you want to add your own agent hooks.
The guide for the docker image says to either mount a volume containing the hooks to the `BUILDKITE_HOOKS_PATH` dir or fork your own docker image and include your hook scripts in that image.
As `/var/buildkite` is an emptyDir the only way, I found, to populate it, would be to copy from the image to the emptyDir shared-dir using an entrypoint script.

I talked with @sj26 via mail about the original problem. This PR adds additional documentation for this case.
While there might be other ways to fix this specific issue (e.g. setting `BUILDKITE_HOOKS_PATH` back to the default outside of the emptyDir share, populate the hooks dir with a configmap similar to the entrydir configmap) this way is the most backwards compatible way I could imagine.

Happy to discuss other solutions instead of this way.


**Special notes for your reviewer**:
Does only improve docs, so no need to bump the chart version.
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
