### PR TITLE
Add pod lifecycle.

### DIFF
--- a/stable/agent/Chart.yaml
+++ b/stable/agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Buildkite Agent Chart
 name: agent
-version: 0.5.1
+version: 0.5.2
 appVersion: 3.25.0
 icon: https://buildkite.com/_next/static/assets/assets/images/brand-assets/buildkite-logo-portrait-on-light-61fc0230.png
 keywords:

--- a/stable/agent/README.md
+++ b/stable/agent/README.md
@@ -93,6 +93,7 @@ Parameter | Description | Default
 `dind.image` | Image to use for Docker-in-Docker (DinD) pod container | `docker:19.03-dind`
 `dind.port` | Port Docker-in-Docker (DinD) daemon listens on as REST request proxy | `2375`
 `dind.resources` | Pod resource requests & limits for dind sidecar (if enabled) | `{}`
+`terminationGracePeriodSeconds` | Duration in seconds the pod needs to terminate gracefully | `30`
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/stable/agent/templates/deployment.yaml
+++ b/stable/agent/templates/deployment.yaml
@@ -76,6 +76,13 @@ spec:
 {{- if .Values.extraEnv }}
 {{ toYaml .Values.extraEnv | nindent 12 }}
 {{- end }}
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - kill -s SIGTERM `/bin/pidof buildkite-agent` && while pidof -q buildkite-agent; do sleep 1; done
           livenessProbe:
 {{ toYaml .Values.livenessProbe | indent 12 }}
           resources:
@@ -127,6 +134,7 @@ spec:
       securityContext:
 {{ toYaml . | indent 8 }}
 {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       volumes:
 {{- if .Values.volumes }}{{ toYaml .Values.volumes | nindent 8 }}{{- end }}
 {{- if .Values.enableHostDocker }}

--- a/stable/agent/values.yaml
+++ b/stable/agent/values.yaml
@@ -187,3 +187,7 @@ dind:
   # requests:
   #  cpu: 100m
   #  memory: 128Mi
+
+# Duration in seconds the pod needs to terminate gracefully.
+# May be increased to allow pipelines to complete successfully before the pod is terminated.
+terminationGracePeriodSeconds: 30


### PR DESCRIPTION
We were experiencing `agent lost` errors in our deployment pipelines
semi-regularly.
This is because when agent pods were asked to go down by our
cluster-autoscaler, they would stop immediately without allowing the
pipeline run to complete.

This commit adds a `preStop` lifecycle to the pod that sends a signal to
the agent to tell it to stop gracefully when it has finished running its
current job, and then waits for the agent to terminate.

This combined with increasing the `terminationGracePeriodSeconds` to a
value large enough to allow the pipelines to complete has eliminated
our broken builds due to the agents stopping prematurely.

The `terminationGracePeriodSeconds` is set to the Kubernetes default of
30 seconds, and would need to be increased by the end user for the
desired result (unless all their pipelines complete in < 30s that is).

Signed-off-by: Jim Barber <jim.barber@healthengine.com.au>

<!--
Thank you for contributing to buildkite/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
our review guidelines:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a TravisCI
will run across your changes, do linting and then install the chart.
Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ x] Chart Version bumped
- [ x] Variables are documented in the README.md
