### PR TITLE
Removing ineffective graceful shutdown code

### DIFF
--- a/stable/agent/Chart.yaml
+++ b/stable/agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Buildkite Agent Chart
 name: agent
-version: 0.5.2
+version: 0.5.3
 appVersion: 3.25.0
 icon: https://buildkite.com/_next/static/assets/assets/images/brand-assets/buildkite-logo-portrait-on-light-61fc0230.png
 keywords:

--- a/stable/agent/templates/deployment.yaml
+++ b/stable/agent/templates/deployment.yaml
@@ -76,13 +76,6 @@ spec:
 {{- if .Values.extraEnv }}
 {{ toYaml .Values.extraEnv | nindent 12 }}
 {{- end }}
-          lifecycle:
-            preStop:
-              exec:
-                command:
-                  - /bin/sh
-                  - -c
-                  - kill -s SIGTERM `/bin/pidof buildkite-agent` && while pidof -q buildkite-agent; do sleep 1; done
           livenessProbe:
 {{ toYaml .Values.livenessProbe | indent 12 }}
           resources:


### PR DESCRIPTION
**What this PR does / why we need it**: This PR removes the preStop lifecycle hook intended for graceful shutdown, because is actually killing both the agent and the job immediately. The default behaviour of the **terminationGracePeriodSeconds** variable is already taking care of gracefully shutting down the pods. 
The  code for [tini](https://github.com/krallin/tini/blob/b9f42a0e7bb46efea0c9e3d8610c96ab53b467f8/src/tini.c#L523-L534) only forwards the signals to the process which it specifically starts, not all children processes.


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ x] Chart Version bumped
