### PR TITLE
Option to remove ineffective graceful shutdown code

### DIFF
--- a/stable/agent/templates/deployment.yaml
+++ b/stable/agent/templates/deployment.yaml
@@ -76,6 +76,31 @@ spec:
 {{- if .Values.extraEnv }}
 {{ toYaml .Values.extraEnv | nindent 12 }}
 {{- end }}
+{{- if .Values.lifecycle.useDefault }}
+{{- if or .Values.lifecycle.preStop .Values.lifecycle.postStart }}
+{{ fail "lifecycle.useDefault set to true, but lifecycle.preStop/lifecycle.postStart specified"}}
+{{- end }}
+          # DEFAULT LIFECYCLE HOOK
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - kill -s SIGTERM `/bin/pidof buildkite-agent` && while pidof -q buildkite-agent; do sleep 1; done
+{{- else if or .Values.lifecycle.preStop .Values.lifecycle.postStart }}
+          lifecycle:
+            # LIFECYCLE PRE STOP
+{{- if .Values.lifecycle.preStop }}
+            preStop:
+{{- toYaml .Values.lifecycle.preStop | nindent 14 }}
+{{- end }}
+            # LIFECYCLE POST START
+{{- if .Values.lifecycle.postStart }}
+            postStart:
+{{- toYaml .Values.lifecycle.postStart | nindent 14 }}
+{{- end }}
+{{- end }}
           livenessProbe:
 {{ toYaml .Values.livenessProbe | indent 12 }}
           resources:

--- a/stable/agent/values.yaml
+++ b/stable/agent/values.yaml
@@ -191,3 +191,19 @@ dind:
 # Duration in seconds the pod needs to terminate gracefully.
 # May be increased to allow pipelines to complete successfully before the pod is terminated.
 terminationGracePeriodSeconds: 30
+
+# Control the lifecycle management for the deployment
+lifecycle:
+  # if useDefault is true, we will use the buildkite/charts default for managing
+  # the lifecycle of the pod. Specifically, we will kill all "buildkite-agent"
+  # processes in the container before shutting down. Please note that there is
+  # some concern that, on some some container images, this will have the
+  # negative effect of causing builds to stop as well. See
+  # https://github.com/buildkite/charts/pull/87 for more discussion
+  useDefault: true
+
+  # Both preStop and postStart are optional values to be executed for the
+  # containers' lifecycle. Note that these cannot be specified if useDefault is
+  # true See: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
+  preStop: {}
+  postStart: {}


### PR DESCRIPTION
What this PR does / why we need it: This PR removes the preStop lifecycle hook intended for graceful shutdown, because is actually killing both the agent and the job immediately. The default behaviour of the terminationGracePeriodSeconds variable is already taking care of gracefully shutting down the pods.
The code for tini only forwards the signals to the process which it specifically starts, not all children processes.

Note that this is a successor to #87 with the feedback from @rimusz. @DavidVtwilio is on PTO so thought I'd quickly hack this together. I'm hoping this is about what you were asking for? The behavior, by default, remains the same. I've also through in relevant hooks for just straight up overriding the preStop and postStart lifecycle.

Please also note that I do not have full confidence in my Helm abilities -- especially my Helm stylistic ability.