### PR TITLE
Adds volumeMounts to dind container

### DIFF
--- a/stable/agent/Chart.yaml
+++ b/stable/agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Buildkite Agent Chart
 name: agent
-version: 0.5.4
+version: 0.5.5
 appVersion: 3.25.0
 icon: https://buildkite.com/_next/static/assets/assets/images/brand-assets/buildkite-logo-portrait-on-light-61fc0230.png
 keywords:

--- a/stable/agent/README.md
+++ b/stable/agent/README.md
@@ -93,6 +93,7 @@ Parameter | Description | Default
 `dind.image` | Image to use for Docker-in-Docker (DinD) pod container | `docker:19.03-dind`
 `dind.port` | Port Docker-in-Docker (DinD) daemon listens on as REST request proxy | `2375`
 `dind.resources` | Pod resource requests & limits for dind sidecar (if enabled) | `{}`
+`dind.volumeMounts` | Extra volumeMounts configuration | `nil`
 `terminationGracePeriodSeconds` | Duration in seconds the pod needs to terminate gracefully | `30`
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.

--- a/stable/agent/templates/deployment.yaml
+++ b/stable/agent/templates/deployment.yaml
@@ -136,15 +136,15 @@ spec:
           - name: DOCKER_TLS_CERTDIR
             value: ""
           volumeMounts:
-          {{- if .Values.dind.volumeMounts }}{{ toYaml .Values.dind.volumeMounts | nindent 12 }}{{- end }}
-          - name: "docker-graph-storage"
-            mountPath: "/var/lib/docker"
-          - name: shared-volume
-            mountPath: "/var/buildkite"
-          {{- if .Values.registryCreds.gcrServiceAccountKey }}
-          - name: service-key
-            mountPath: /etc/service_key
-          {{- end }}
+            {{- if .Values.dind.volumeMounts }}{{ toYaml .Values.dind.volumeMounts | nindent 12 }}{{- end }}
+            - name: "docker-graph-storage"
+              mountPath: "/var/lib/docker"
+            - name: shared-volume
+              mountPath: "/var/buildkite"
+            {{- if .Values.registryCreds.gcrServiceAccountKey }}
+            - name: service-key
+              mountPath: /etc/service_key
+            {{- end }}
           resources:
 {{ toYaml .Values.dind.resources | indent 12 }}
 {{- end }}

--- a/stable/agent/templates/deployment.yaml
+++ b/stable/agent/templates/deployment.yaml
@@ -136,6 +136,7 @@ spec:
           - name: DOCKER_TLS_CERTDIR
             value: ""
           volumeMounts:
+          {{- if .Values.dind.volumeMounts }}{{ toYaml .Values.dind.volumeMounts | nindent 12 }}{{- end }}
           - name: "docker-graph-storage"
             mountPath: "/var/lib/docker"
           - name: shared-volume

--- a/stable/agent/values.yaml
+++ b/stable/agent/values.yaml
@@ -187,6 +187,7 @@ dind:
   # requests:
   #  cpu: 100m
   #  memory: 128Mi
+  volumeMounts: {}
 
 # Duration in seconds the pod needs to terminate gracefully.
 # May be increased to allow pipelines to complete successfully before the pod is terminated.


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds the ability to have volume mounts in the `dind` container.

A popular request is to have a "cache" disk between builds/steps, since many builds are executed using the buildkite docker plugin, the `volumes:` [argument](https://github.com/buildkite-plugins/docker-buildkite-plugin#volumes-optional-array-or-boolean) has no effect, unless the volume is also mounted onto the `dind` container.

In my specific use-case, I am mounting an NFS share which is mounted across the deployment.

Obviously I cannot mount on top of the `shared-volume`.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
