### PR TITLE
Allow overriding MTU for DIND

### DIFF
--- a/stable/agent/Chart.yaml
+++ b/stable/agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Buildkite Agent Chart
 name: agent
-version: 0.5.5
+version: 0.5.6
 appVersion: 3.25.0
 icon: https://buildkite.com/_next/static/assets/assets/images/brand-assets/buildkite-logo-portrait-on-light-61fc0230.png
 keywords:

--- a/stable/agent/README.md
+++ b/stable/agent/README.md
@@ -92,6 +92,7 @@ Parameter | Description | Default
 `dind.enabled` | Enable preconfigured Docker-in-Docker (DinD) pod configuration | `false`
 `dind.image` | Image to use for Docker-in-Docker (DinD) pod container | `docker:19.03-dind`
 `dind.port` | Port Docker-in-Docker (DinD) daemon listens on as REST request proxy | `2375`
+`dind.mtu` | The MTU used for Docker-inDocker (DinD) daemon. Must be lower than pod networking interface | `1500`
 `dind.resources` | Pod resource requests & limits for dind sidecar (if enabled) | `{}`
 `dind.volumeMounts` | Extra volumeMounts configuration | `nil`
 `terminationGracePeriodSeconds` | Duration in seconds the pod needs to terminate gracefully | `30`

--- a/stable/agent/templates/deployment.yaml
+++ b/stable/agent/templates/deployment.yaml
@@ -130,6 +130,7 @@ spec:
 {{- if .Values.dind.enabled }}
         - name: dind
           image: {{ .Values.dind.image | default "docker:19.03-dind" }}
+          args: "--mtu {{ .Values.dind.mtu || default "1500" }}"
           securityContext:
             privileged: true
           env:

--- a/stable/agent/templates/deployment.yaml
+++ b/stable/agent/templates/deployment.yaml
@@ -132,7 +132,7 @@ spec:
           image: {{ .Values.dind.image | default "docker:19.03-dind" }}
           args:
             - "--mtu"
-            - {{ .Values.dind.mtu | default "1500" }}
+            - "{{ .Values.dind.mtu | default "1500" }}"
           securityContext:
             privileged: true
           env:

--- a/stable/agent/templates/deployment.yaml
+++ b/stable/agent/templates/deployment.yaml
@@ -130,7 +130,7 @@ spec:
 {{- if .Values.dind.enabled }}
         - name: dind
           image: {{ .Values.dind.image | default "docker:19.03-dind" }}
-          args: "--mtu {{ .Values.dind.mtu || default "1500" }}"
+          args: "--mtu {{ .Values.dind.mtu | default "1500" }}"
           securityContext:
             privileged: true
           env:

--- a/stable/agent/templates/deployment.yaml
+++ b/stable/agent/templates/deployment.yaml
@@ -130,7 +130,9 @@ spec:
 {{- if .Values.dind.enabled }}
         - name: dind
           image: {{ .Values.dind.image | default "docker:19.03-dind" }}
-          args: "--mtu {{ .Values.dind.mtu | default "1500" }}"
+          args:
+            - "--mtu"
+            - {{ .Values.dind.mtu | default "1500" }}
           securityContext:
             privileged: true
           env:

--- a/stable/agent/values.yaml
+++ b/stable/agent/values.yaml
@@ -177,6 +177,7 @@ dind:
   image: docker:19.03-dind
   port: 2375
   resources: {}
+  mtu: 1500
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR allows overriding of the `mtu` option for DIND. If the pod network interface has a lower MTU, i.e. 1450, and the Docker default of 1500 is used, any packet above 1450 will not reach DIND. This causes weird issues, such as network connectivity appearing to be okay within the DIND sidecar, but any network request that downloads or uses packets above 1450 will appear to stall and never timeout, as the TCP connection can handshake correctly and send SYNs and ACKs, but the actual data packets above 1450 will never reach the container.

#### Checklist
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
