### PR TITLE
Support externalSecretName

### DIFF
--- a/stable/agent/Chart.yaml
+++ b/stable/agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Buildkite Agent Chart
 name: agent
-version: 0.5.6
+version: 0.6.0
 appVersion: 3.25.0
 icon: https://buildkite.com/_next/static/assets/assets/images/brand-assets/buildkite-logo-portrait-on-light-61fc0230.png
 keywords:

--- a/stable/agent/README.md
+++ b/stable/agent/README.md
@@ -35,6 +35,13 @@ helm install --name bk-agent --namespace buildkite buildkite/agent \
   --set registryCreds.gcrServiceAccountKey="$(cat gcr_service_account.key | base64)"
 ```
 
+Alternatively, an external secret can be referenced for the agent token and agent SSH key:
+```console
+helm install --name bk-agent --namespace buildkite buildkite/agent \
+  --set agent.externalSecretName="buildkite-agent-secret",agent.tags="role=production" \
+  --set agent.externalSecretTokenKey="agent-token",agent.externalSecretSSHKey="agent-ssh"
+```
+
 > **Note**: if your pipeline uses docker for build images or run containers, you must set `dind.enabled` to `true`.
 
 Where `--set` values contain:
@@ -67,13 +74,16 @@ Parameter | Description | Default
 `image.repository` | Image repository | `buildkite/agent`
 `image.tag` | Image tag | ``
 `image.pullPolicy` | Image pull policy | `IfNotPresent`
-`agent.token` | Agent token | Must be specified
+`agent.externalSecretName` | Name of a `Secret` to load the agent token and agent private SSH key from. Takes precedence over `.agent.token` and `.privateSshKey` | `nil`
+`agent.externalSecretTokenKey` | Name of the Key in the above secret where the agent token is located | `agent-token`
+`agent.externalSecretSSHKey` | Name of the key in the above secret where the agent private SSH is located | `nil`
+`agent.token` | Agent token | Must be specified unless `agent.externalSecretName` is set
 `agent.tags` | Agent tags | `role=agent`
 `enableHostDocker` | Mount docker socket | `true`
 `podSecurityContext` | Pod security context to set | `{}`
 `securityContext` | Container security context to set | `{}`
 `extraEnv` | Agent extra env vars | `nil`
-`privateSshKey` | Agent ssh key for git access | `nil`
+`privateSshKey` | Agent ssh key for git access. Also see `.agent.externalSecretName` | `nil`
 `registryCreds.gcrServiceAccountKey` | GCP Service account json key | `nil`
 `registryCreds.dockerConfig` | Private registry docker config.json | `nil`
 `entrypointd` | Add files to /docker-entrypoint.d/ via a ConfigMap | `{}`

--- a/stable/agent/templates/deployment.yaml
+++ b/stable/agent/templates/deployment.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.agent.token }}
 apiVersion: {{ template "deployment.apiVersion" . }}
 kind: Deployment
 metadata:
@@ -48,13 +47,27 @@ spec:
 {{- end }}
           env:
             # BUILDKITE AGENT ENV VARS
+            {{- if .Values.agent.externalSecretName }}
+            - name: BUILDKITE_AGENT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.agent.externalSecretName }}
+                  key: {{ .Values.agent.externalSecretTokenKey }}
+            {{- if .Values.agent.externalSecretSSHKey }}
+            - name: SSH_PRIVATE_RSA_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.agent.externalSecretName }}
+                  key: {{ .Values.agent.externalSecretSSHKey }}
+            {{- end }}
+            {{- else }}
+            {{- if .Values.agent.token }}
             - name: BUILDKITE_AGENT_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: {{ template "fullname" . }}
                   key: agent-token
-            - name: BUILDKITE_AGENT_TAGS
-              value: "{{ .Values.agent.tags }}"
+            {{- end }}
             {{- if .Values.privateSshKey }}
             - name: SSH_PRIVATE_RSA_KEY
               valueFrom:
@@ -62,6 +75,9 @@ spec:
                   name: {{ template "fullname" . }}
                   key: agent-ssh
             {{- end }}
+            {{- end }}
+            - name: BUILDKITE_AGENT_TAGS
+              value: "{{ .Values.agent.tags }}"
             {{- if .Values.dind.enabled }}
             - name: DOCKER_HOST
               value: "tcp://localhost:{{ .Values.dind.port | default "2375" }}"
@@ -198,4 +214,3 @@ spec:
       affinity:
 {{ toYaml .Values.affinity | indent 8 }}
     {{- end }}
-{{- end }}

--- a/stable/agent/templates/secret.yaml
+++ b/stable/agent/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if or .Values.agent.token .Values.privateSshKey }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,7 +10,10 @@ metadata:
     heritage: {{ .Release.Service }}
 type: Opaque
 data:
+{{- if .Values.agent.token }}
   agent-token: {{ .Values.agent.token | b64enc }}
+{{- end }}
 {{- if .Values.privateSshKey }}
   agent-ssh: {{ .Values.privateSshKey | b64enc }}
+{{- end }}
 {{- end }}

--- a/stable/agent/values.yaml
+++ b/stable/agent/values.yaml
@@ -16,6 +16,9 @@ agent:
   token: ""
   # Agent tags, which can be used to assign jobs
   tags: "role=agent"
+  externalSecretName: ""
+  externalSecretTokenKey: "agent-token"
+  externalSecretSSHKey: ""
 
 # Enable mounting the hosts docker socket into the agent container
 enableHostDocker: true


### PR DESCRIPTION
* Default behavior of the chart is unchanged, **except** that the `Deployment` is now always created, even if `.agent.token` is unset.
  * Did anyone actually depend on this behavior?
* If `.agent.externalSecretName` is set:
  * No longer create the `Secret`
  * Load the agent token and agent private SSH key from the `.agent.externalSecretName`
  * Allow users to override the key names within this secret away from the defaults

**What this PR does / why we need it**: Allows users to bring their own `Secret` for the agent token and private SSH key This does not include changes to the registry and GCR credentials, since those were already optional.

**Which issue this PR fixes**: fixes #95 

**Special notes for your reviewer**:

#### Checklist
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
