### PR TITLE
Ensuring compatibility with Kubernetes 1.25: Add support for Pdb policy/v1 API

### DIFF
--- a/stable/agent/Chart.yaml
+++ b/stable/agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Buildkite Agent Chart
 name: agent
-version: 0.6.2
+version: 0.6.3
 appVersion: 3.25.0
 icon: https://buildkite.com/_next/static/assets/assets/images/brand-assets/buildkite-logo-portrait-on-light-61fc0230.png
 keywords:

--- a/stable/agent/templates/_helpers.tpl
+++ b/stable/agent/templates/_helpers.tpl
@@ -33,3 +33,14 @@ Set the Deployment API version based on the version of Kubernetes the chart is b
 {{- print "apps/v1" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Define Pdb apiVersion
+*/}}
+{{- define "pdb.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "policy/v1" }}
+{{- printf "policy/v1" -}}
+{{- else }}
+{{- printf "policy/v1beta1" -}}
+{{- end }}
+{{- end }}

--- a/stable/agent/templates/pod-disruption-budget.yaml
+++ b/stable/agent/templates/pod-disruption-budget.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podDisruptionBudget.enabled }}
-apiVersion: policy/v1beta1
+apiVersion: {{ template "pdb.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "fullname" . }}


### PR DESCRIPTION
This PR updates our Kubernetes deployment to ensure compatibility with version 1.25. As part of this update, we have added support for Pdb policy/v1 API in our deployment. The Pdb policy/v1 API is required for Kubernetes 1.25, and this update will ensure that our deployment continues to function correctly after the Kubernetes version upgrade.

To implement this update, we have made the necessary changes to our deployment scripts and configuration files to integrate the Pdb policy/v1 API. We have also conducted thorough testing to ensure that this update does not impact the functionality of your deployment or introduce any new issues.

Overall, this PR is a critical update to ensure the compatibility of our deployment with the latest version of Kubernetes. We are confident that this update will enable us to continue to provide a stable and reliable service to the  users.

++++++++++++++++++++++++++++++++++++++++++++

**What this PR does / why we need it**:

We are proposing to add a block for Pdb version 1 to the existing Buildkite chart in order to support our project requirements. This will involve integrating the Pdb v1 block into the existing Buildkite pipeline and ensuring compatibility with other blocks and dependencies. Our team has already tested Pdb version 1 in a local environment and confirmed its functionality. The inclusion of this block will improve our ability to effectively debug and troubleshoot our project.

**What this PR does / why we need it**:
# As of the PDB support only v1beta1 due to which our we are not able to integrate in our existing application 
To resolve this issue we have included a if else block in _helpers.tpl & modified the poddisruptionbudget.yaml file 
Please check it and approve the same 


**Special notes for your reviewer**:
Reference for the same 
Please check the Reference where v1beta is not supported with Kubernetes 1.25 which will imapct all users who are on kube 1.25 

https://kubernetes.io/docs/reference/using-api/deprecation-guide/#poddisruptionbudget-v125


https://github.com/argoproj/argo-helm/blob/bc4e00b836335731e4b78dd19e396992dfb068fe/charts/argo-events/templates/_helpers.tpl#L129-L138

