### PR TITLE
Support Deployment annotation configuration

### DIFF
--- a/stable/agent/Chart.yaml
+++ b/stable/agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Buildkite Agent Chart
 name: agent
-version: 0.6.3
+version: 0.6.4
 appVersion: 3.25.0
 icon: https://buildkite.com/_next/static/assets/assets/images/brand-assets/buildkite-logo-portrait-on-light-61fc0230.png
 keywords:

--- a/stable/agent/README.md
+++ b/stable/agent/README.md
@@ -79,6 +79,7 @@ Parameter | Description | Default
 `agent.externalSecretSSHKey` | Name of the key in the above secret where the agent private SSH is located | `nil`
 `agent.token` | Agent token | Must be specified unless `agent.externalSecretName` is set
 `agent.tags` | Agent tags | `role=agent`
+`agent.annotation` | Extra annotations for the generated Deployment | `{}`
 `enableHostDocker` | Mount docker socket | `true`
 `podSecurityContext` | Pod security context to set | `{}`
 `securityContext` | Container security context to set | `{}`

--- a/stable/agent/templates/deployment.yaml
+++ b/stable/agent/templates/deployment.yaml
@@ -7,6 +7,10 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- if .Values.agent.annotations }}
+  annotations:
+{{ toYaml .Values.agent.annotations | indent 4 }}
+{{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/stable/agent/values.yaml
+++ b/stable/agent/values.yaml
@@ -19,6 +19,8 @@ agent:
   externalSecretName: ""
   externalSecretTokenKey: "agent-token"
   externalSecretSSHKey: ""
+  # Agent Deployment annotations
+  annotations: {}
 
 # Enable mounting the hosts docker socket into the agent container
 enableHostDocker: true


### PR DESCRIPTION
Add support to configure `.metadata.annotations` on the main agent `Deployment` resource


**What this PR does / why we need it**:
Chart lacked the ability to configure `.metadata.annotations` on the `Deployment`


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
