### PR TITLE
Use ssm secrets

### DIFF
--- a/.buildkite/pipeline.deploy.yml
+++ b/.buildkite/pipeline.deploy.yml
@@ -5,7 +5,12 @@ env:
   GIT_COMMITTER_EMAIL: "support@buildkite.com"
 
 steps:
-  - label: ":shipit:" 
+  - label: ":shipit:"
     command: "make build release"
     concurrency_group: "${BUILDKITE_PIPELINE_SLUG}/deploy"
     concurrency: 1
+    plugins:
+      - aws-assume-role-with-web-identity#v1.0.0:
+          role-arn: arn:aws:iam::445615400570:role/pipeline-buildkite-helm-charts-deploy
+      - aws-ssm#v1.0.0:
+            GH_TOKEN: /pipelines/buildkite/helm-charts-deploy/gh-token

--- a/Makefile
+++ b/Makefile
@@ -44,4 +44,4 @@ release:
 	cd dist-repo && \
 		git add *.tgz index.yaml && \
 		git commit --message "Update to buildkite/charts@${COMMIT}" && \
-		git push origin gh-pages
+		git push https://dummy:$${GH_TOKEN}@github.com/buildkite/charts.git gh-pages


### PR DESCRIPTION
We're slowly migrating open source pipelines into their own clusters. This pattern includes using pipeline-specific OIDC assumable roles for access to any resources needed; and injecting secrets explicitly to steps, using the ssm plugin, rather than using s3 secrets.